### PR TITLE
Workflows dev update for package submission

### DIFF
--- a/.github/workflows/auto_merge.yml
+++ b/.github/workflows/auto_merge.yml
@@ -1,0 +1,33 @@
+name: Auto-Merge Validated Packages
+
+on:
+  pull_request_target:
+    types: [labeled]
+    branches:
+      - packages
+    paths:
+      - '*/hatch_metadata.json'
+
+jobs:
+  auto-merge:
+    if: github.event.label.name == 'reviewed' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.HATCH_WORKFLOW_APP_ID }}
+          private_key: ${{ secrets.HATCH_WORKFLOW_APP_PRIVATE_KEY }}
+          
+      - name: Auto-approve PR
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          
+      - name: Auto-merge PR
+        uses: pascalgn/automerge-action@v0.16.4
+        env:
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          MERGE_METHOD: squash
+          MERGE_LABELS: validation-passed, reviewed

--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -1,0 +1,100 @@
+name: Package PR Validation
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    branches:
+      - packages #only run on PRs to the packages branch
+    paths:
+      - '*/hatch_metadata.json' #only run on PRs that change hatch_metadata.json files, meaning any change leads to at least a version bump.
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      package_dirs: ${{ steps.filter.outputs.changes_files }}
+      multiple_packages_changed: ${{ steps.check-multiple.outputs.multiple_packages }}
+      package_name: ${{ steps.filter.outputs.package_name }} #only if a unique package is found
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect changed package directories
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          list-files: json
+          filters: |
+            changes:
+              - '*/hatch_metadata.json'
+      
+      - name: Check for changes in multiple packages
+        id: check-multiple
+        run: |
+          # Extract base directories (package names) from the changed files using bash parameter expansion
+          CHANGED_FILES='${{ steps.filter.outputs.changes_files }}'
+          PACKAGE_DIRS=()
+          
+          # Process each file path to extract package name using bash parameter expansion
+          for FILE in $(echo "$CHANGED_FILES" | jq -r '.[]'); do
+            # Extract package name (everything before the first slash)
+            PACKAGE=${FILE%%/*}
+            PACKAGE_DIRS+=("$PACKAGE")
+          done
+          
+          # Get unique package directories
+          UNIQUE_PACKAGES=$(printf "%s\n" "${PACKAGE_DIRS[@]}" | sort -u)
+          PACKAGE_COUNT=$(echo "$UNIQUE_PACKAGES" | grep -v "^$" | wc -l)
+          
+          echo "Package directories changed:"
+          echo "$UNIQUE_PACKAGES"
+          echo "Total unique package directories: $PACKAGE_COUNT"
+          
+          # Set output if multiple packages were changed
+          if [ "$PACKAGE_COUNT" -gt 1 ]; then
+            echo "multiple_packages=true" >> $GITHUB_OUTPUT
+            echo "::error::PR contains changes to multiple packages: $UNIQUE_PACKAGES. Please submit separate PRs for each package."
+            exit 1
+          else
+            echo "multiple_packages=false" >> $GITHUB_OUTPUT
+            echo "package_name=$(echo "$UNIQUE_PACKAGES" | grep -v "^$")" >> $GITHUB_OUTPUT
+          fi
+  
+  validate-package:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.multiple_packages_changed == 'false' && needs.detect-changes.outputs.package_dirs != '[]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Upload package as artifact
+        id: upload-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hatch-package-${{ steps.check-multiple.outputs.package_name }}
+          path: ${{ steps.package-info.outputs.package_dir }}
+          retention-days: 1
+          if-no-files-found: error
+      
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.HATCH_WORKFLOW_APP_ID }}
+          private_key: ${{ secrets.HATCH_WORKFLOW_APP_PRIVATE_KEY }}
+
+      - name: Trigger Validation Package Workflow in Registry
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: CrackingShells/Hatch-Registry
+          event-type: validate-package
+          client-payload: |- 
+            {
+                "run_id": "${{ github.run_id }}",
+                "workflow_id": "${{ github.workflow }}",
+                "repository": "${{ github.repository }}",
+                "pr_number": "${{ github.event.pull_request.number }}",
+                "artifact_name": "hatch-package-${{ steps.check-multiple.outputs.package_name }}",
+                "package_name": "${{ steps.check-multiple.outputs.package_name }}"
+            }

--- a/.github/workflows/release_package.yml
+++ b/.github/workflows/release_package.yml
@@ -1,0 +1,93 @@
+name: Release Package
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/**'
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      package_dirs: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch all history to detect changes
+          
+      - name: Detect changed package directories
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          list-files: json
+          filters: |
+            changes:
+              - 'packages/*/**'
+  
+  create-release:
+    needs: detect-changes
+    if: ${{ needs.detect-changes.outputs.package_dirs != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package_dir: ${{ fromJSON(needs.detect-changes.outputs.package_dirs) }}
+      fail-fast: false
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract package info
+        id: package-info
+        run: |
+          PACKAGE_DIR="${{ matrix.package_dir }}"
+          PACKAGE_NAME=$(basename $PACKAGE_DIR)
+          
+          # Extract version from metadata file (adapt based on your format)
+          if [ -f "$PACKAGE_DIR/metadata.json" ]; then
+            VERSION=$(jq -r .version $PACKAGE_DIR/metadata.json)
+          else
+            VERSION=$(date +%Y.%m.%d-%H%M)
+          fi
+          
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release_name=${PACKAGE_NAME}-${VERSION}" >> $GITHUB_OUTPUT
+      
+      - name: Create release artifact
+        run: |
+          mkdir -p release-artifact
+          cp -r ${{ matrix.package_dir }}/* release-artifact/
+          cd release-artifact
+          zip -r ../${{ steps.package-info.outputs.release_name }}.zip .
+      
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.HATCH_WORKFLOW_APP_ID }}
+          private_key: ${{ secrets.HATCH_WORKFLOW_APP_PRIVATE_KEY }}
+      
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ steps.package-info.outputs.release_name }}.zip
+          name: ${{ steps.package-info.outputs.release_name }}
+          tag_name: ${{ steps.package-info.outputs.package_name }}-v${{ steps.package-info.outputs.version }}
+          token: ${{ steps.generate-token.outputs.token }}
+      
+      - name: Trigger registry update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          repository: CrackingShells/Hatch-Registry
+          event-type: add-package
+          client-payload: |- 
+            {
+              "repository": "${{ github.repository }}",
+              "package_name": "${{ steps.package-info.outputs.package_name }}",
+              "version": "${{ steps.package-info.outputs.version }}",
+              "release_tag": "${{ steps.package-info.outputs.package_name }}-v${{ steps.package-info.outputs.version }}"
+            }

--- a/.github/workflows/validate_package.yml
+++ b/.github/workflows/validate_package.yml
@@ -1,4 +1,4 @@
-name: Package Upload Workflow
+name: Validate Package Workflow
 
 on:
   # This workflow can be triggered manually from the GitHub UI


### PR DESCRIPTION
This pull request introduces three new GitHub Actions workflows and updates an existing one to streamline package validation, auto-merging, and release processes for the `packages` branch. These changes enhance automation, enforce single-package PRs, and integrate with `Hatch-Registry` for validation and release.

### New Workflows

#### PR Validation Workflow:
* Added `pr_validation.yml` to validate PRs against the `packages` branch. It ensures that PRs modify only one package at a time by analyzing changes in `hatch_metadata.json` files. If multiple packages are affected, the workflow fails with an error.

#### Auto-Merge Workflow:
* Added `auto_merge.yml` to automatically approve and merge PRs labeled as `reviewed`.

#### Release Workflow (tentative):
* Added `release_package.yml` to detect changes in the `packages` directory on the `main` branch and create a release for each modified package. The workflow generates release artifacts, creates GitHub releases, and triggers an external registry update.
